### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @transferwise/organic-growth


### PR DESCRIPTION
## Context

This is an OG repo but it didn't come up in GitHub Actions Migration planning because we weren't labeled as codeowners.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
